### PR TITLE
added rosalyn page and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ _site
 .jekyll-metadata
 vendor
 **/.DS_Store
+/.vs/Devops Squad Dev Experience/FileContentIndex/255cedce-ecea-42d5-a6f7-409b27d69c34.vsidx
+/.vs/Devops Squad Dev Experience/FileContentIndex/7e1fb98a-0bdd-4c89-baa0-3b81071afb53.vsidx
+/.vs/Devops Squad Dev Experience/FileContentIndex/d01bab7c-d708-4a0b-ada1-f7f5f296f585.vsidx
+/.vs/Devops Squad Dev Experience/v17/.wsuo
+/.vs/Devops Squad Dev Experience/v17/DocumentLayout.json
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json

--- a/docs/6-security-testing/rosalyn.md
+++ b/docs/6-security-testing/rosalyn.md
@@ -1,0 +1,10 @@
+---
+title: Rosalyn Analyzers
+parent: Security & Testing
+has_children: false
+nav_order: 5
+---
+
+## Rosalyn Analyzers
+
+tbc


### PR DESCRIPTION
The most significant changes include the update to the `.gitignore` file to ignore several new files and directories, and the creation of a new Markdown file named `rosalyn.md`.

1. The `.gitignore` file has been updated to ignore several new files and directories. This includes the `.DS_Store` files in any directory, several `.vsidx` files in the `Devops Squad Dev Experience/FileContentIndex/` directory, a `.wsuo` file and a `DocumentLayout.json` file in the `Devops Squad Dev Experience/v17/` directory, and a few other files in the `.vs/` directory. This change ensures that these files, which are not needed in the repository, will not be tracked by Git.

2. A new Markdown file named `rosalyn.md` has been created. This file appears to be for a webpage, with metadata specified in the front matter at the top of the file. The metadata includes the page's title, its parent page, its navigation order, and the fact that it does not have any child pages. The content of the page currently includes a heading and a placeholder for future content.

References to the code changes can be found in the `.gitignore` and `rosalyn.md` files.